### PR TITLE
feat(parse): update to new parsing and prefixes

### DIFF
--- a/rust/jolocom_native_utils/Cargo.toml
+++ b/rust/jolocom_native_utils/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-keri = "0.1.2"
+keri = "0.2.0"
 universal_wallet = "0.2.1"
 serde = "1.0"
 serde_json = "1.0"

--- a/rust/jolocom_native_utils/src/lib.rs
+++ b/rust/jolocom_native_utils/src/lib.rs
@@ -2,27 +2,13 @@ pub mod did_document;
 pub mod wallet;
 use did_document::{state_to_did_document, DIDDocument};
 use keri::{
-    error::Error,
-    event_message::{parse_signed_message_json, validate_events, SignedEventMessage},
+    event_message::parse::{signed_event_stream_validate, signed_message},
     prefix::Prefix,
 };
 
 pub fn validate_events_str(kel_str: &str, method_name: &str) -> Result<String, String> {
-    let str_events: Vec<String> = match serde_json::from_str(&kel_str) {
-        Ok(k) => k,
-        Err(e) => return Err(e.to_string()),
-    };
-    let kel: Vec<SignedEventMessage> = match str_events
-        .iter()
-        .map(|e| parse_signed_message_json(e))
-        .collect::<Result<Vec<SignedEventMessage>, Error>>()
-    {
-        Ok(k) => k,
-        Err(e) => return Err(e.to_string()),
-    };
-
-    let ddo: DIDDocument = match validate_events(&kel) {
-        Ok(s) => state_to_did_document(s, method_name),
+    let ddo: DIDDocument = match signed_event_stream_validate(&kel_str) {
+        Ok((_, s)) => state_to_did_document(s, method_name),
         Err(e) => return Err(e.to_string()),
     };
 
@@ -33,8 +19,8 @@ pub fn validate_events_str(kel_str: &str, method_name: &str) -> Result<String, S
 }
 
 pub fn get_id_from_event_str(event: &str) -> Result<String, String> {
-    match parse_signed_message_json(event) {
-        Ok(ev) => Ok(ev.event_message.event.prefix.to_str()),
+    match signed_message(event) {
+        Ok((_, ev)) => Ok(ev.event_message.event.prefix.to_str()),
         Err(e) => Err(e.to_string()),
     }
 }


### PR DESCRIPTION
adopts the much more ergonomic parsing api, as well as support for blake3 self-addressing prefixes and a fix for the blake2b-256 prefix (blake2b has 512bit output by default, so blake2b-256 is disabled until a variable width impl is added)