### PR TITLE
Fix github actions script

### DIFF
--- a/scripts/actions/install-sccache.ps1
+++ b/scripts/actions/install-sccache.ps1
@@ -17,5 +17,5 @@ curl -LO $url
 tar -xzvf "$basename.tar.gz"
 ls $basename/
 . $basename/sccache --start-server
-echo "::add-path::$(pwd)/$basename"
-echo "::set-env name=RUSTC_WRAPPER::sccache"
+echo "$(pwd)/$basename" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+echo "name=RUSTC_WRAPPER::sccache" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append


### PR DESCRIPTION
after github [deprecated some insecure commands](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/)

NOTE: tests are still broken because ursa github repo has changed from [master to main](https://github.com/hyperledger/ursa/commit/35f1f2603db63ce24356e7e7e3d973b80fee8c71) and needs to be updated in keriox cargo.toml